### PR TITLE
Fix crash in glyph replacement plugin

### DIFF
--- a/plugins-local/glyph-replacement-slovak.rb
+++ b/plugins-local/glyph-replacement-slovak.rb
@@ -13,10 +13,13 @@ Jekyll::Hooks.register :site, :post_render do |site|
     content.gsub!(/ (atď)\.([ \)])/i, '&nbsp;\1.\2')
     # Nonbreaking spaces in two-part expressions.
     content.gsub!(/ t\. j\. /i, ' t.&nbsp;j. ')
-  end  
+  end
 
   site.documents.each do |page|
-    Jekyll.logger.error "Undefined page.output for '#{page.path}'. Consider excluding this file" if not page.respond_to? :output
+    if not page.respond_to? :output
+      Jekyll.logger.error "Undefined page.output for '#{page.path}'. Consider excluding this file"
+      continue
+    end
     replace!(page.output)
   end
 


### PR DESCRIPTION
In case the `page` object has no `output` property, an error gets logged but execution continues as though nothing has happened. We need to skip processing the document in case an error like this occurs.

Follow-up to faktaoklimatu/web-core#61.