### PR TITLE
 Potlačenie emoji zobrazenia šípky

### DIFF
--- a/_config.local.yml
+++ b/_config.local.yml
@@ -72,3 +72,4 @@ jekyll-archives:
 kramdown:
   math_engine: katex
   smart_quotes: sbquo,lsquo,bdquo,ldquo
+  footnote_backlink: "↩︎"


### PR DESCRIPTION
Změna řetězce, kterým se v poznámkách pod čarou odkazuje zpět do textu, na verzi se selektorem varianty VS15 (U+FE0E). Tento selektor zajistí, že se šipky nezobrazí jako emoji, což je výchozí chování např. v Safari na iPhonu.