### PR TITLE
Nová složka pro ilustrace a lepší og:image

### DIFF
--- a/_data/lang.yml
+++ b/_data/lang.yml
@@ -29,9 +29,11 @@ topic:
   intro-title: "Úvod"
   nutshell-id: "v-kocke"
   nutshell-title: "V kocke"
+  series-prefix: "Séria: "
 
 text:
   toc: "Obsah"
+  tldr: "Zhrnutie"
   study:
     study: "Štúdia"
     summary: "Hlavné závery"
@@ -47,6 +49,7 @@ text:
     licence-proof: "informácie o licencii"
   explainer:
     explainer: "Explainer"
+    series: "Diel série"
     source: "Zdroj"
     author: "Autor"
     licence: "Licencia"
@@ -59,6 +62,16 @@ text:
     all-tag: "Ďalšie infografiky, štúdie a datasety k téme"
   rss:
     more-online: "Viac informácií nájdete v plnej verzii na našom webe."
+  section-link: "Odkaz na sekciu"
+  series:
+    previous: "<< Predchádzajúci diel"
+    next: "Ďalší diel >>"
+  figure:
+    source: "Zdroj:"
+  publication:
+    publication: "Naše publikácie"
+    download: "Celý text publikácie v PDF"
+    sponsor: "Zadávateľ"
 
 sidebar:
   download:

--- a/collections/_pages/index.md
+++ b/collections/_pages/index.md
@@ -64,7 +64,7 @@ Klimatická zmena je zložitý komplex navzájom previazaných javov. Údaje, s 
 {%- for topic in sorted_topics %}
 <div class="topic-tile col-6 col-md-4 p-0">
 <a class="mb-3 my-md-3" href="{{ topic.url }}">
-  <img class="mx-3" loading="eager" src="/assets/topics/{{ topic.slug }}_mini.svg" alt="{{ topic.title }}">
+  <img class="mx-3" loading="eager" src="/assets/illustrations/{{ topic.slug }}_mini.svg" alt="{{ topic.title }}">
   <h3 class="mx-3">{{ topic.title | capitalize }}</h3>
 </a>
 </div>


### PR DESCRIPTION
Tento PR nasazuje konverzi svg illustrací do PNG (kvůli og:image) a dělá drobnou aktualizaci v umístění svgs témat.

Více na https://github.com/faktaoklimatu/web-core/pull/225.

Protože aktualizuje web-core po dlouhé době, přidává i překlady nových řetězců (by Google Translate, kontrolovala Viera).

Preview: https://sk-fakty-o-klime--preview-og-il7c1l3j.web.app
(náhledy obrázků pro stránky témat a publikace tam stále nefunguje, protože používá absolute_url filtr, který nefunguje s preview adresami - dává všude hlavní web)